### PR TITLE
fix: correct type import of Undici

### DIFF
--- a/packages/opentelemetry-instrumentation-undici/src/types.ts
+++ b/packages/opentelemetry-instrumentation-undici/src/types.ts
@@ -1,10 +1,10 @@
 import { Span } from "@opentelemetry/api";
 import { InstrumentationConfig } from "@opentelemetry/instrumentation";
-import Dispatcher, { DispatchOptions } from "undici/types/dispatcher";
+import { Dispatcher } from "undici";
 
 export interface HookInfo {
   dispatcher: Dispatcher;
-  options: DispatchOptions;
+  options: Dispatcher.DispatchOptions;
 }
 
 export type HookFunction = (span: Span, hookInfo: HookInfo) => void;


### PR DESCRIPTION
Without this I get

```
../../node_modules/opentelemetry-instrumentation-undici/dist/src/types.d.ts:3:22 - error TS2614: Module '"undici/types/dispatcher"' has no exported member 'DispatchOptions'. Did you mean to use 'import DispatchOptions from
"undici/types/dispatcher"' instead?

3 import Dispatcher, { DispatchOptions } from "undici/types/dispatcher";
```