### PR TITLE
Include dependencies needed by opentelemetry-instrumentation-ws

### DIFF
--- a/packages/opentelemetry-instrumentation-ws/package.json
+++ b/packages/opentelemetry-instrumentation-ws/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opentelemetry-instrumentation-ws",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "source": "src/index.ts",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
@@ -19,6 +19,8 @@
   },
   "dependencies": {
     "@opentelemetry/api": "^1.3.0",
+    "@opentelemetry/core": "^1.3.0",
+    "@opentelemetry/instrumentation": "^0.34.0",
     "@opentelemetry/instrumentation-http": "^0.35.0",
     "is-promise": "^4.0.0"
   },
@@ -26,7 +28,6 @@
     "ws": "^8.5.0"
   },
   "devDependencies": {
-    "@opentelemetry/instrumentation": "^0.34.0",
     "@opentelemetry/semantic-conventions": "^1.9.0",
     "@swc/core": "^1.3.25",
     "@swc/jest": "^0.2.24",

--- a/packages/opentelemetry-instrumentation-ws/src/index.ts
+++ b/packages/opentelemetry-instrumentation-ws/src/index.ts
@@ -58,7 +58,7 @@ export class WSInstrumentation extends InstrumentationBase<WS> {
   protected _requestSpans = new WeakMap<IncomingMessage, Span>();
 
   constructor(config: WSInstrumentationConfig = {}) {
-    super("opentelemetry-instrumentation-ws", "0.4.2", config);
+    super("opentelemetry-instrumentation-ws", "0.4.3", config);
   }
 
   protected init() {

--- a/yarn.lock
+++ b/yarn.lock
@@ -879,6 +879,14 @@
   dependencies:
     "@opentelemetry/semantic-conventions" "1.9.0"
 
+"@opentelemetry/core@^1.3.0":
+  version "1.15.0"
+  resolved "https://registry.npmjs.org/@opentelemetry/core/-/core-1.15.0.tgz#2ba928df0443732825a72a766c2edae9a7f9863f"
+  integrity sha512-GGTS6BytfaN8OgbCUOnxg/a9WVsVUj0484zXHZuBzvIXx7V4Tmkb0IHnnhS7Q0cBLNLgjNuvrCpQaP8fIvO4bg==
+  dependencies:
+    "@opentelemetry/semantic-conventions" "1.15.0"
+    tslib "^2.3.1"
+
 "@opentelemetry/instrumentation-http@^0.35.0":
   version "0.35.0"
   resolved "https://registry.yarnpkg.com/@opentelemetry/instrumentation-http/-/instrumentation-http-0.35.0.tgz#cfcd26dad5e2a5415d6763d5c37599e4f2931f03"
@@ -906,6 +914,13 @@
     require-in-the-middle "^5.0.3"
     semver "^7.3.2"
     shimmer "^1.2.1"
+
+"@opentelemetry/semantic-conventions@1.15.0":
+  version "1.15.0"
+  resolved "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.15.0.tgz#e6173daa5fd61f353b02c858001388bf26e9d059"
+  integrity sha512-f3wwFrFyCpGrFBrFs7lCUJSCSCGyeKG52c+EKeobs3Dd29M75yO6GYkt6PkYPfDawxSlV5p+4yJPPk8tPObzTQ==
+  dependencies:
+    tslib "^2.3.1"
 
 "@opentelemetry/semantic-conventions@1.9.0", "@opentelemetry/semantic-conventions@^1.9.0":
   version "1.9.0"
@@ -4371,6 +4386,11 @@ tslib@^1.8.1:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
+
+tslib@^2.3.1:
+  version "2.6.2"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.6.2.tgz#703ac29425e7b37cd6fd456e92404d46d1f3e4ae"
+  integrity sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==
 
 tsutils@^3.21.0:
   version "3.21.0"


### PR DESCRIPTION
Links to where these dependencies are used:

1. [`@opentelemetry/core`](https://github.com/gadget-inc/opentelemetry-instrumentations/blob/0225c8e9d59044c33fcea424b7ce821b3626fd65/packages/opentelemetry-instrumentation-ws/src/index.ts#L4)
2. [`@opentelemetry/instrumentation`](https://github.com/gadget-inc/opentelemetry-instrumentations/blob/07f0c54249eb1bf9bef6da46845ace0540675e1f/packages/opentelemetry-instrumentation-ws/src/types.ts#L2)

Noticed these when one of our own repositories using pnpm was running a script and failing to find these dependencies.