### PR TITLE
Create a new timestamped span to enable let us keep the proper endTime

### DIFF
--- a/packages/opentelemetry-instrumentation-ws/src/types.ts
+++ b/packages/opentelemetry-instrumentation-ws/src/types.ts
@@ -1,5 +1,5 @@
-import { Span } from "@opentelemetry/api";
-import { InstrumentationConfig } from "@opentelemetry/instrumentation";
+import type { Span } from "@opentelemetry/api";
+import type { InstrumentationConfig } from "@opentelemetry/instrumentation";
 
 export interface HookInfo {
   payload: any | any[];


### PR DESCRIPTION
Adding a wrapper around the parent span so that we can store the backdated time
